### PR TITLE
fix _parseTZID for standard time

### DIFF
--- a/lib/Horde/Icalendar.php
+++ b/lib/Horde/Icalendar.php
@@ -1321,7 +1321,7 @@ class Horde_Icalendar
             } elseif ($i === $n-1) {
                 // last transition in this year is before the current date
                 // use 'to' value
-                $change_times[$i]['to'];
+                return $change_times[$i]['to'];
             }
         }
 


### PR DESCRIPTION
This PR is a bit complicated.

Currently the transition offsets will sometimes be incorrectly be calculated.
This can be reproduced by subscribing to a horde calendar in evolution and then create a new calendar entry from evolution. The created entry will have a time that is one hour to early. This is because it uses the daylight savings time instead of the standard time.

We need to sort the `$change_times` by transition time first (low->high). Then we can take the `from` value of first one that is after the current time. If all valid transition times are before the the current time, we can just take the `to` value of the last one.

If none of the transition times are valid anymore, we take the `to` value of the last defined transition, which should therefore still be the current offset.

This worked in my tests. Though I am not 100% certain that this always works, because I do not completely understand the iCalendar specification.


Here is an example of icalendar data that lead to a wrong offset:
```
BEGIN:VCALENDAR
CALSCALE:GREGORIAN
PRODID:-//Ximian//NONSGML Evolution Calendar//EN
VERSION:2.0
BEGIN:VTIMEZONE
TZID:Europe/Berlin
X-LIC-LOCATION:Europe/Berlin
BEGIN:DAYLIGHT
TZNAME:CEST
TZOFFSETFROM:+0100
TZOFFSETTO:+0200
DTSTART:19810329T020000
RRULE:FREQ=YEARLY;UNTIL=20370329T010000Z;BYDAY=-1SU;BYMONTH=3
END:DAYLIGHT
BEGIN:STANDARD
TZNAME:CET
TZOFFSETFROM:+0200
TZOFFSETTO:+0100
DTSTART:19961027T030000
RRULE:FREQ=YEARLY;UNTIL=20361026T010000Z;BYDAY=-1SU;BYMONTH=10
END:STANDARD
END:VTIMEZONE
BEGIN:VEVENT
UID:d9b5b22248ffb07b483dd247c713a8cc5bffccea
DTSTAMP:20230113T090407Z
DTSTART;TZID=Europe/Berlin:20230208T120000
DTEND;TZID=Europe/Berlin:20230208T122500
SEQUENCE:2
TRANSP:OPAQUE
CLASS:PUBLIC
CREATED:20230113T092953Z
LAST-MODIFIED:20230113T092953Z
END:VEVENT
END:VCALENDAR
```